### PR TITLE
credit control : replace compatible for BDUprint

### DIFF
--- a/bdu_reports/views/credit_history.xml
+++ b/bdu_reports/views/credit_history.xml
@@ -7,7 +7,7 @@
     <field name="model">account.invoice</field>
     <field name="inherit_id" ref="account.invoice_tree"/>
     <field name="arch" type="xml">
-      <field name="user_id" position="replace">
+      <field name="company_id" position="replace">
         <field name="account_manager_id"/>
       </field>
     </field>


### PR DESCRIPTION
now replacing company_id instead of user_id, because:
- BDUprint uses user_id
- showing company_id has no added_value