### PR TITLE
BDU product base, BDU announcement, BDU paid digital subscriptions

### DIFF
--- a/bdu_announcements/models/announcement_config.py
+++ b/bdu_announcements/models/announcement_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import pdb
 import base64, datetime, httplib, json, logging, pdb, requests, urllib
 from odoo import models, fields, api
 from odoo.exceptions import ValidationError
@@ -56,7 +56,7 @@ class AnnouncementConfig(models.Model):
         else :
             return 0
 
-
+    #hook for automated actions
     @api.multi
     def automated_run(self):
         configurations = self.search([])
@@ -72,10 +72,10 @@ class AnnouncementConfig(models.Model):
             self.write({})
             return self.do_send()
 
-    
+    #loop started by automated run (above) or send button push
     @api.multi 
     def do_send(self):
-        #collect data based on config 	    
+        #collect config data to run with 	    
         config = self[0] 
         if not config.oldest_synced :
             oldest_synced = datetime.datetime(1970,1,1,0,0)
@@ -85,12 +85,13 @@ class AnnouncementConfig(models.Model):
         if not config.begin :
             raise ValidationError("Please provide a begin date")
             return False
-
+        
         #get changed orderlines since oldest_non_synced
-        announcements=self.env['sale.order.line'].search([('ad_class', '=', config.ad_class.id),\
+        announcements=self.env['sale.order.line'].search([('custom_orderline', '=', 'Announcement'),\
                                                           ('write_date', '>', config.begin+" T00:00:00")]).\
                       sorted(key = lambda r : r.write_date)
 
+        #abandon early if no changes
         if not announcements :
             config.latest_run     = datetime.date.today()
             config.latest_status  = "N.A."
@@ -99,14 +100,7 @@ class AnnouncementConfig(models.Model):
             _logger.info("No new announcements to sync to website")
             return True
 
-        #prepare api
-        url         = config.server.strip()+config.method.strip()
-        b_auth      = bytes(config.user+":"+config.password)
-        headers     = {'authorization': "Basic " + base64.b64encode( b_auth),
-                       'cache-control': "no-cache",
-                       'content-type' : "application/x-www-form-urlencoded",
-                      }
-
+        #init loop
         all_good      = True
         ok_recs       = 0
         errors        = 0
@@ -114,49 +108,31 @@ class AnnouncementConfig(models.Model):
         status        = ""
         message       = ""
         oldest_synced = datetime.datetime.strptime(config.begin+" T00:00:00", "%Y-%m-%d T%H:%M:%S")
-        
+
         #loop through changed orderlines
         for announcement in announcements :
-            payload={}
-            payload['orderlinenr'] = announcement['id']
-            payload['count']       = str(int(announcement['product_uom_qty']))
+            result = self.send_orderline(announcement)
+            if result == "no material" :
+                all_good       = False
+                no_material   += 1
+                message       += "<br>"+str(announcement.order_id.name)+" - "+str(announcement.id)+" : No material. Not sent."
+            elif result == "ok" :
+                oldest_synced  = announcement['write_date']
+                ok_recs       += 1
+                message       += "<br>"+str(announcement.order_id.name)+" - "+str(announcement.id)+" : Synced"
+            else : #bad response
+                all_good       = False
+                errors        += 1
+                status         = result.split(',')[1]
+                message       += "<br>"+str(announcement.order_id.name)+" - "+str(announcement.id)+" : Bad response, reason = "+result.split(',', 2)[2]
 
-            if announcement['from_date'] :
-                payload['startdate']   = announcement['from_date'].replace("-","")   #target format yyyymmdd
-            else :
-                payload['startdate']   = False
-            if announcement['to_date'] :
-                payload['enddate']     = announcement['to_date'].replace("-","")     #target format yyyymmdd
-            else :
-                payload['enddate']     = False
-            payload['domain']      = "5"
-            payload['url2material']= announcement['url_to_material']
-            
-            if announcement['url_to_material'] :
-                response=requests.post(url, data=payload, headers=headers)
-                if response.status_code != requests.codes.ok :  #not equal 200 ok
-                    all_good=False
-                    errors  += 1
-                    status  = str(response.status_code)
-                    
-                    message += "<br>"+str(announcement['id'])+" "+response.json()['message']
-                else :
-                    ok_recs += 1
-                    message += "<br>"+str(announcement['id'])+"Synced"
-            else :
-                all_good=False
-                no_material += 1
-                message     += "<br>"+str(announcement['id'])+ ": no material" 
 
-            if all_good :
-                oldest_synced = announcement['write_date']
-
-        #leave testimonial with config info
+        #leave testimonial of run result
         if all_good :
             config.oldest_synced  = oldest_synced
             config.latest_run     = datetime.datetime.utcnow().strftime('UTC %Y-%m-%d %H:%M:%S ')
             config.latest_success = datetime.date.today()
-            config.latest_status  = str(response.status_code)
+            config.latest_status  = "Last record processed : "+result
             config.latest_reason  = "Sync OK"
             config.write({})
             _logger.info("Successfull shipment of %d announcement orderlines created/changed after %s T00:00:00",\
@@ -169,7 +145,61 @@ class AnnouncementConfig(models.Model):
             prologue              = "%d lines without material. %d errors. %d records OK. Oldest_non_synced kept at first error/no material." % (no_material, errors, ok_recs)
             config.latest_reason  = prologue+message
             config.write({})
-            _logger.info(message)
+            _logger.info("Finished processing with errors. See connector page for details.")
             return False
+
+    #method to be called by order update or loop (above)
+    @api.multi 
+    def send_orderline(self, orderline):
+        #use config to prep api call      
+        config = self[0] 
+        url         = config.server.strip()+config.method.strip()
+        b_auth      = bytes(config.user+":"+config.password)
+        headers     = {'authorization': "Basic " + base64.b64encode( b_auth),
+                       'cache-control': "no-cache",
+                       'content-type' : "application/x-www-form-urlencoded",
+                      }
+
+        #only send if url_to_material available or if publication cancelled
+        if orderline.product_uom_qty !=0 and not orderline.url_to_material :
+            return "no material"
+        else :
+            payload={}
+            payload['source']        = "Odoo"
+            payload['nr']            = orderline.id
+            payload['url2material']  = orderline.url_to_material
+
+            if orderline.order_id.state == 'sale' :
+                payload['count']     = str(int(orderline.product_uom_qty)) 
+            else :
+                payload['count']     = "0"
+
+            #custom orderline variables
+            payload['firstname']     = orderline.announcement_firstname
+            payload['lastname']      = orderline.announcement_lastname
+            payload['city']          = orderline.announcement_city
+            payload['startdate']     = orderline.announcement_from_date   #target format yyyy-mm-dd
+            payload['enddate']       = orderline.announcement_to_date     #target format yyyy-mm-dd
+            
+            publications=[]
+            for issue in orderline.announcement_adv_issue_ids :
+                publication = {}
+                publication['title'] = issue.parent_id.code
+                publication['date']  = issue.issue_date
+                publications.append(publication)
+            payload['publications'] = json.dumps(publications)
+
+            #send it
+            #response=requests.post(url, data=payload, headers=headers)
+            response = requests.request("POST", url, data=payload, headers=headers)
+            if response.status_code == requests.codes.ok :  # equal 200 ok
+                return "ok"
+            elif response.status_code == 502 :
+                return "bad response,"+str(response.status_code)+", "+response.content
+            else:
+                #pdb.set_trace()
+                msg=str(response.json()['message'])
+                return "bad response,"+str(response.status_code)+", "+msg
+
 
 	

--- a/bdu_paid_digital_subscriptions/models/digital_subscribers_config.py
+++ b/bdu_paid_digital_subscriptions/models/digital_subscribers_config.py
@@ -133,7 +133,7 @@ class DigitalSubscribersConfig(models.Model):
             ('subscription', '=', True),
             ('state', '=', 'sale'),
             ('title', 'in', td),
-            ('product_template_id.digital_subscription', '=', True),
+            #('product_template_id.digital_subscription', '=', True),
         ]
         digital_subscriptions = orderlines.search(domain).sorted(key=lambda r: r.order_id.partner_shipping_id) 
         if len(digital_subscriptions)==0 :

--- a/bdu_product_base/models/sale.py
+++ b/bdu_product_base/models/sale.py
@@ -8,7 +8,7 @@ from odoo import api, fields, models
 class ProductBaseOrderLine(models.Model):
     _inherit = 'sale.order.line'
     
-    custom_orderline  = fields.Char(compute="set_custom_orderline", string='Custom orderline') 
+    custom_orderline  = fields.Char(compute="set_custom_orderline", string='Custom orderline',  store=True) 
 
     @api.multi
     @api.depends('product_id')


### PR DESCRIPTION
Product base now has field custom borderline stored to facilitate filtering by e.g. connectors that want to transport info to different producers. For now only Drupal sites. Soon for shipping display requests to Google Ad Manager.

BDU announcement is adapted to new API. 

BDU paid digital subscriptions now do not select on the "digital only" boolean in product template. So now active subscriptions for digital titles (only or both digital and physical) are selected.


